### PR TITLE
fix: raster images not showing because of pagination style changed in the STAC

### DIFF
--- a/src/services/apiSTAC.js
+++ b/src/services/apiSTAC.js
@@ -10,11 +10,10 @@ export const fetchAllFromSTACAPI = async (STACApiUrl) => {
       }
       const jsonResult = await response.json();
       requiredResult.push(...getResultArray(jsonResult));
-
       // need to pull in remaining data based on the pagination information
-      const { matched, returned } = jsonResult.context;
-      if (matched > returned) {
-        let allData = await fetchAllDataSTAC(STACApiUrl, matched);
+      const { numberMatched, numberReturned } = jsonResult;
+      if (numberMatched > numberReturned) {
+        let allData = await fetchAllDataSTAC(STACApiUrl, numberMatched);
         requiredResult = [...allData];
       }
       return requiredResult;


### PR DESCRIPTION
Raster datasets were not showing. Turns out the pagination information to get all the data was changed.